### PR TITLE
feat!: add NavigatorStartUserStory widget

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -20,9 +20,8 @@ class Home extends StatelessWidget {
   const Home({super.key});
 
   @override
-  Widget build(BuildContext context) => startNavigatorUserStory(
-        context,
-        config,
+  Widget build(BuildContext context) => NavigatorStartUserStory(
+        configuration: config,
         onComplete: (context) async {
           await Navigator.of(context).pushReplacement(
             MaterialPageRoute(builder: (context) => const HomeEntry()),

--- a/lib/src/models/start_configuration.dart
+++ b/lib/src/models/start_configuration.dart
@@ -67,4 +67,10 @@ class StartUserStoryConfiguration {
 
   /// Allow popping from introduction, defaults to true
   final bool canPopFromIntroduction;
+
+  /// returns true if the userstory should start with the introduction screen
+  bool get startWithIntroScreen =>
+      splashScreenBuilder == null &&
+      splashScreenCenterWidget == null &&
+      splashScreenBackgroundColor == null;
 }

--- a/lib/src/user_stories/flutter_start_userstory_navigator.dart
+++ b/lib/src/user_stories/flutter_start_userstory_navigator.dart
@@ -4,6 +4,29 @@ import 'package:flutter/material.dart';
 import 'package:flutter_start/flutter_start.dart';
 import 'package:flutter_start/src/services/killswitch_service.dart';
 
+/// Initial screen of the user story.
+///
+/// Use this when defining an initial route.
+class NavigatorStartUserStory extends StatelessWidget {
+  const NavigatorStartUserStory({
+    required this.onComplete,
+    this.configuration = const StartUserStoryConfiguration(),
+    super.key,
+  });
+
+  final StartUserStoryConfiguration configuration;
+  final void Function(BuildContext context) onComplete;
+
+  @override
+  Widget build(BuildContext context) {
+    if (configuration.showIntroduction) {
+      return _introduction(configuration, context, onComplete);
+    }
+
+    return _splashScreen(configuration, context, onComplete);
+  }
+}
+
 /// Enter the start user story with the Navigator 1.0 API.
 ///
 /// Requires a Navigator widget to exist in the given [context].
@@ -13,17 +36,30 @@ import 'package:flutter_start/src/services/killswitch_service.dart';
 /// [onComplete] triggers as soon as the userstory is finished.
 ///
 /// The context provided here is a context has a guaranteed navigator.
-Widget startNavigatorUserStory(
+Future<void> startNavigatorUserStory(
   BuildContext context,
   StartUserStoryConfiguration configuration, {
   required void Function(BuildContext context) onComplete,
-}) {
-  if (configuration.splashScreenBuilder == null &&
-      configuration.splashScreenCenterWidget == null &&
-      configuration.splashScreenBackgroundColor == null) {
-    return _introduction(configuration, context, onComplete);
+}) async {
+  var initialRoute = MaterialPageRoute(
+    builder: (context) => _splashScreen(
+      configuration,
+      context,
+      onComplete,
+    ),
+  );
+
+  if (configuration.startWithIntroScreen) {
+    initialRoute = MaterialPageRoute(
+      builder: (context) => _introduction(
+        configuration,
+        context,
+        onComplete,
+      ),
+    );
   }
-  return _splashScreen(configuration, context, onComplete);
+
+  await Navigator.of(context).push(initialRoute);
 }
 
 Widget _splashScreen(


### PR DESCRIPTION
This also changes the startNavigatorUserStory function return type from a widget to Future<void>, as that starts the story. The widget immediately displays the initial screen. This is a breaking change.