### PR TITLE
fix: Check with the service if the introduction should be shown befor…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.2.3
+- Added check if introduction should be shown according to the service before showing the introduction at all
+
 ## 4.2.2
 - Added custom navigator in the root of the navigator user-story
 

--- a/lib/src/user_stories/flutter_start_userstory_navigator.dart
+++ b/lib/src/user_stories/flutter_start_userstory_navigator.dart
@@ -104,22 +104,25 @@ Widget _splashScreen(
 
     if (configuration.useKillswitch && isAllowedToPassThrough) return;
 
-    if ((!configuration.showIntroduction) && context.mounted) {
-      onComplete(context);
-      return;
-    }
+    var introService = configuration.introductionService ??
+        IntroductionService(SharedPreferencesIntroductionDataProvider());
 
-    if (context.mounted) {
-      await navigator.pushReplacement(
-        MaterialPageRoute(
-          builder: (context) => _introduction(
-            configuration,
-            context,
-            onComplete,
-          ),
+    var shouldShowIntroduction =
+        configuration.showIntroduction && await introService.shouldShow();
+
+    if (!context.mounted) return;
+
+    if (!shouldShowIntroduction) return onComplete(context);
+
+    await navigator.pushReplacement(
+      MaterialPageRoute(
+        builder: (context) => _introduction(
+          configuration,
+          context,
+          onComplete,
         ),
-      );
-    }
+      ),
+    );
   }
 
   var builder = configuration.splashScreenBuilder;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_start
 description: "Flutter_start is a package that allows you to jumpstart your application with a splashScreen, introduction and a home."
-version: 4.2.2
+version: 4.2.3
 
 publish_to: https://forgejo.internal.iconica.nl/api/packages/internal/pub
 

--- a/test/_test.dart
+++ b/test/_test.dart
@@ -1,0 +1,14 @@
+// This is an example unit test.
+//
+// A unit test tests a single function, method, or class. To learn more about
+// writing unit tests, visit
+// https://flutter.dev/docs/cookbook/testing/unit/introduction
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Plus Operator', () {
+    test('should add two numbers together', () {
+      expect(1 + 1, 2);
+    });
+  });
+}


### PR DESCRIPTION
…e actually showing

When removing this, the introduction is briefly shown before calling the onComplete