### PR TITLE
Change splashscreen default background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 4.2.5
+- Removed cupertino_icons dependency from pubspec.yaml
 - Removed the default black color value from splashScreenBackgroundColor if it was not provided in the configuration, so it defaults to ThemeData.scaffoldBackgroundColor
 
 ## 4.2.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.2.5
+- Removed the default black color value from splashScreenBackgroundColor if it was not provided in the configuration, so it defaults to ThemeData.scaffoldBackgroundColor
+
 ## 4.2.4
 - Fixed the userstory to always call the splashScreenFuture and killswitchservice logic when a custom splashScreenBuilder is provided
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Flutter_start is a package that allows you to jumpstart your application with a 
 To use this package, add flutter_start as a dependency in your pubspec.yaml file:
 
 ```yaml
-  flutter_start:
-    git:
-      url: https://github.com/Iconica-Development/flutter_start
-      ref: 4.1.0
+dependencies:
+  flutter_feedback: 
+    hosted: https://forgejo.internal.iconica.nl/api/packages/internal/pub
+    version: <current version>
 ```
 
 ## go_router
@@ -131,7 +131,7 @@ The `StartUserStoryConfiguration` has its own parameters, as specified below:
 | `minimumSplashScreenDuration` | The minimum duration the splashScreen should be shown. Defaults to 3 seconds |
 | `splashScreenFuture` | The future to be completed before the splashScreen is completed |
 | `splashScreenCenterWidget` | The widget to be shown in the center of the splashScreen |
-| `splashScreenBackgroundColor` | The color of the splashScreen background. Defaults to Color(0xff212121) |
+| `splashScreenBackgroundColor` | The color of the splashScreen background. Defaults to ThemeData.scaffoldBackgroundColor |
 | `canPopFromIntroduction` | Allow popping from introduction, defaults to true. Defaults to true |
 | `killswitchService` | The service to override the default killswitch service |
 | `showSplashScreen` | A boolean to show the splashScreen or not. Defaults to true |

--- a/lib/src/models/start_configuration.dart
+++ b/lib/src/models/start_configuration.dart
@@ -20,7 +20,7 @@ class StartUserStoryConfiguration {
     this.minimumSplashScreenDuration = 3,
     this.splashScreenFuture,
     this.splashScreenCenterWidget,
-    this.splashScreenBackgroundColor = const Color(0xff212121),
+    this.splashScreenBackgroundColor,
     this.canPopFromIntroduction = true,
     this.killswitchService,
     this.showSplashScreen = true,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_start
 description: "Flutter_start is a package that allows you to jumpstart your application with a splashScreen, introduction and a home."
-version: 4.2.4
+version: 4.2.5
 
 publish_to: https://forgejo.internal.iconica.nl/api/packages/internal/pub
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  cupertino_icons: ">=1.0.2 <2.0.0"
   go_router: ">=14.2.0 <15.0.0"
   http: ">=1.2.1 <2.0.0"
   package_info_plus: ">=8.0.0 <9.0.0"


### PR DESCRIPTION
The default color was set to a black color for the iconica instagram app. Instead of making all splashscreens that color by default it should just use the scaffold color and the iconica app should either set the scaffold to black or provide a custom splashscreencolor